### PR TITLE
Implemented retrieval of new Spotify access token from refresh token

### DIFF
--- a/myapp/.env
+++ b/myapp/.env
@@ -60,5 +60,5 @@ KEY=rHbaqmfdhmdrDDPIytYhwSRzcvpOesjZ
 SPOTIFY_ID=bcd5e565bc464208a1a03fde424733a4
 SPOTIFY_SECRET=1ec3def0425e4f85a2f3378b221c23bf
 
-# Spotify Callback URL
-SPOTIFY_CALLBACK_URL=http://localhost:4000
+# Localhost URL
+LOCALHOST_URL=http://localhost:4000

--- a/myapp/.env
+++ b/myapp/.env
@@ -60,5 +60,5 @@ KEY=rHbaqmfdhmdrDDPIytYhwSRzcvpOesjZ
 SPOTIFY_ID=bcd5e565bc464208a1a03fde424733a4
 SPOTIFY_SECRET=1ec3def0425e4f85a2f3378b221c23bf
 
-# Localhost url
-LOCALHOST_URL=http://localhost:4000
+# Spotify Callback URL
+SPOTIFY_CALLBACK_URL=http://localhost:4000

--- a/myapp/data/spotifytoken.go
+++ b/myapp/data/spotifytoken.go
@@ -147,11 +147,31 @@ func (t *SpotifyToken) Upsert(spotifytoken SpotifyToken) (int, error) {
 	spotifytoken.UpdatedAt = time.Now()
 
 	res2, err2 := collection.Insert(spotifytoken)
+
 	if err2 != nil {
-		return 0, err
+		return 0, err2
 	}
 
 	id := getInsertID(res2.ID())
 
 	return id, nil
+}
+
+// UpdateAccessToken updates the access_token, updated_at, and access_expiry fields of
+// a user's spotifytoken record
+func (t *SpotifyToken) UpdateAccessToken(accessToken string, accessExpiry time.Time) error {
+	collection := upper.Collection(t.Table())
+
+	// update the calling struct's values
+	t.AccessToken = accessToken
+	t.UpdatedAt = time.Now()
+	t.AccessTokenExpiry = accessExpiry
+
+	// use UpdateReturning to automatically identify the record in the db our calling struct is referring to
+	err := collection.UpdateReturning(t)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/myapp/data/spotifytoken.go
+++ b/myapp/data/spotifytoken.go
@@ -146,10 +146,10 @@ func (t *SpotifyToken) Upsert(spotifytoken SpotifyToken) (int, error) {
 	spotifytoken.CreatedAt = time.Now()
 	spotifytoken.UpdatedAt = time.Now()
 
-	res2, err2 := collection.Insert(spotifytoken)
+	res2, err := collection.Insert(spotifytoken)
 
-	if err2 != nil {
-		return 0, err2
+	if err != nil {
+		return 0, err
 	}
 
 	id := getInsertID(res2.ID())

--- a/myapp/handlers/auth-handlers.go
+++ b/myapp/handlers/auth-handlers.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/base32"
 	"fmt"
+	"golang.org/x/oauth2"
 	"log"
 	"math/rand"
 	"myapp/data"
@@ -14,6 +15,10 @@ import (
 
 var auth = spotify.Authenticator{}
 var state string
+
+// if length of spotScopes changes, be sure to update functions that call this array
+// within this .go file
+var spotScopes = [2]string{spotify.ScopeUserTopRead, spotify.ScopeUserReadRecentlyPlayed}
 
 func (h *Handlers) UserRegister(w http.ResponseWriter, r *http.Request) {
 	err := h.App.Render.Page(w, r, "register", nil, nil)
@@ -70,6 +75,7 @@ func (h *Handlers) PostUserLogin(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		// User does not have current token, so redirect to Spotify auth
 		http.Redirect(w, r, "/users/spotauth", http.StatusSeeOther)
+		return
 	}
 
 	// User has current token, so redirect to matches page
@@ -84,13 +90,8 @@ func (h *Handlers) Logout(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handlers) SpotifyAuthorization(w http.ResponseWriter, r *http.Request) {
-	callback := os.Getenv("LOCALHOST_URL") + "/spotauth/callback"
-	auth = spotify.NewAuthenticator(
-		callback,
-		// these scopes may need to be changed out for this app
-		spotify.ScopeUserTopRead,
-		spotify.ScopeUserReadRecentlyPlayed)
-
+	callback := os.Getenv("SPOTIFY_CALLBACK_URL") + "/spotauth/callback"
+	auth = spotify.NewAuthenticator(callback, spotScopes[0], spotScopes[1])
 	randomBytes := make([]byte, 16)
 	_, err := rand.Read(randomBytes)
 	if err != nil {
@@ -117,6 +118,92 @@ func (h *Handlers) SpotifyAuthorization(w http.ResponseWriter, r *http.Request) 
 }
 
 func (h *Handlers) SpotifyAuthorizationCallback(w http.ResponseWriter, r *http.Request) {
+	tok, err := auth.Token(state, r)
+	if err != nil {
+		http.Error(w, "Couldn't get token", http.StatusForbidden)
+		log.Fatal(err)
+	}
+	if st := r.FormValue("state"); st != state {
+		http.NotFound(w, r)
+		log.Fatalf("State mismatch: %s != %s\n", st, state)
+	}
+
+	spotclient := auth.NewClient(tok)
+	fmt.Fprintf(w, "Login Completed!")
+
+	_, err = spotclient.CurrentUser()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	userID := h.App.Session.GetInt(r.Context(), "userID")
+	if userID == 0 || userID == -1 {
+		log.Fatal("The user_id of the current user could not be found in the session data.")
+	}
+
+	// Write the new refresh token and new access token to a new
+	// spotifytoken struct, and assign that to the current User's SpotifyToken variable.
+	spottoken := data.SpotifyToken{
+		UserID:            userID,
+		AccessToken:       tok.AccessToken,
+		RefreshToken:      tok.RefreshToken,
+		AccessTokenExpiry: tok.Expiry,
+	}
+
+	spottoken.Upsert(spottoken)
+
+	http.Redirect(w, r, "/matches", http.StatusSeeOther)
+}
+
+func (h *Handlers) NewAccessTokenRequest(w http.ResponseWriter, r *http.Request) {
+	callback := os.Getenv("SPOTIFY_CALLBACK_URL") + "/newspotaccesstoken/callback"
+	auth = spotify.NewAuthenticator(callback, spotScopes[0], spotScopes[1])
+	randomBytes := make([]byte, 16)
+	_, err := rand.Read(randomBytes)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// get the user's spotifytoken, put that info into a new oauth2.Token struct
+	userID := h.App.Session.GetInt(r.Context(), "userID")
+	userSpotTokens, _ := h.Models.SpotifyTokens.GetSpotifyTokenForUser(userID)
+	oauth2SpotToken := oauth2.Token{
+		AccessToken:  userSpotTokens.AccessToken,
+		TokenType:    "bearer",
+		RefreshToken: userSpotTokens.RefreshToken,
+		Expiry:       userSpotTokens.AccessTokenExpiry,
+	}
+
+	// pass the oauth2 token into NewClient, to set the stage
+	client := auth.NewClient(&oauth2SpotToken)
+
+	// get the new access token, and save it to the user's spotifytoken record in the db
+	newtoken, _ := client.Token()
+	userSpotTokens.AccessToken = newtoken.AccessToken
+	err = userSpotTokens.UpdateAccessToken(newtoken.AccessToken, newtoken.Expiry)
+	if err != nil {
+		log.Fatal(err)
+	} else {
+		fmt.Print("Spotify access token updated successfully!")
+	}
+	//
+	//// redefine state for the refresh-to-access token process
+	//state = base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(randomBytes)
+	//
+	//// use state to create the url to access Spotify
+	//url := auth.AuthURL(state)
+	//
+	//// If the browser is already logged in to a Spotify account, use Spotify
+	//// to ask them if they want to continue with that Spotify account.
+	//url = url + "&show_dialog=true"
+	//
+	//// redirecting to Spotify login!
+	//http.Redirect(w, r, url, http.StatusSeeOther)
+
+	http.Redirect(w, r, "/matches", http.StatusSeeOther)
+}
+
+func (h *Handlers) NewAccessTokenAssign(w http.ResponseWriter, r *http.Request) {
 	tok, err := auth.Token(state, r)
 	if err != nil {
 		http.Error(w, "Couldn't get token", http.StatusForbidden)

--- a/myapp/handlers/auth-handlers.go
+++ b/myapp/handlers/auth-handlers.go
@@ -90,7 +90,7 @@ func (h *Handlers) Logout(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handlers) SpotifyAuthorization(w http.ResponseWriter, r *http.Request) {
-	callback := os.Getenv("SPOTIFY_CALLBACK_URL") + "/spotauth/callback"
+	callback := os.Getenv("LOCALHOST_URL") + "/spotauth/callback"
 	auth = spotify.NewAuthenticator(callback, spotScopes[0], spotScopes[1])
 	randomBytes := make([]byte, 16)
 	_, err := rand.Read(randomBytes)
@@ -156,7 +156,7 @@ func (h *Handlers) SpotifyAuthorizationCallback(w http.ResponseWriter, r *http.R
 }
 
 func (h *Handlers) NewAccessTokenRequest(w http.ResponseWriter, r *http.Request) {
-	callback := os.Getenv("SPOTIFY_CALLBACK_URL") + "/newspotaccesstoken/callback"
+	callback := os.Getenv("LOCALHOST_URL") + "/newspotaccesstoken/callback"
 	auth = spotify.NewAuthenticator(callback, spotScopes[0], spotScopes[1])
 	randomBytes := make([]byte, 16)
 	_, err := rand.Read(randomBytes)

--- a/myapp/handlers/handlers.go
+++ b/myapp/handlers/handlers.go
@@ -6,6 +6,7 @@ import (
 	"myapp/data"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -36,14 +37,6 @@ func (h *Handlers) Settings(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-
-		//// get the user's user data from the database
-		//user, err := h.Models.Users.Get(profile.UserID)
-		//if err != nil {
-		//	fmt.Println("Error getting user:", err)
-		//	http.Error(w, err.Error(), http.StatusBadRequest)
-		//	return
-		//}
 
 		// create variables from the grabbed data to send to our view
 		vars := make(jet.VarMap)
@@ -262,6 +255,21 @@ func (h *Handlers) MyMatchResults(w http.ResponseWriter, r *http.Request) {
 func (h *Handlers) Matches(w http.ResponseWriter, r *http.Request) {
 	if !h.App.Session.Exists(r.Context(), "userID") {
 		http.Redirect(w, r, "users/login", http.StatusSeeOther)
+		return
+	}
+
+	// Check the user's spotify access token expiry. If it's within 5 minutes of its
+	// -- expiry, redirect to users/newspotaccesstoken to get a new one from spotify via the refresh token
+	// Get user ID from the session
+	userID := h.App.Session.GetInt(r.Context(), "userID")
+	userSpotTokens, _ := h.Models.SpotifyTokens.GetSpotifyTokenForUser(userID)
+	// convert to east-coat time zone, that's used by time.Time (add 4 hrs)
+	expiry := userSpotTokens.AccessTokenExpiry.Unix() + 14400
+	fiveMinutesFromNow := time.Now().Add(time.Minute * 5).Unix()
+	if expiry < fiveMinutesFromNow {
+		fmt.Println(fiveMinutesFromNow)
+		// go to users/newspotaccesstoken to get the new access token with the refresh token
+		http.Redirect(w, r, "users/newspotaccesstoken", http.StatusSeeOther)
 		return
 	}
 

--- a/myapp/handlers/handlers.go
+++ b/myapp/handlers/handlers.go
@@ -44,10 +44,10 @@ func (h *Handlers) Settings(w http.ResponseWriter, r *http.Request) {
 		vars.Set("profileID", profile.ID)
 		vars.Set("usersProfileID", profile.UserID)
 
-		err2 := h.App.Render.JetPage(w, r, "settings", vars, nil)
-		if err2 != nil {
-			h.App.ErrorLog.Println("error rendering:", err2)
-			http.Error(w, err2.Error(), http.StatusBadRequest)
+		err = h.App.Render.JetPage(w, r, "settings", vars, nil)
+		if err != nil {
+			h.App.ErrorLog.Println("error rendering:", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
 		}
 
 	} else {

--- a/myapp/routes.go
+++ b/myapp/routes.go
@@ -39,7 +39,6 @@ func (a *application) routes() *chi.Mux {
 	})
 
 	a.App.Routes.Get("/spotauth/callback", a.Handlers.SpotifyAuthorizationCallback)
-	a.App.Routes.Get("/spotauth/callback", a.Handlers.SpotifyAuthorizationCallback)
 
 	a.App.Routes.Route("/messages", func(r chi.Router) {
 		r.Get("/", a.Handlers.Messages)

--- a/myapp/routes.go
+++ b/myapp/routes.go
@@ -28,6 +28,7 @@ func (a *application) routes() *chi.Mux {
 		r.Get("/logout", a.Handlers.Logout)
 		r.Get("/register", a.Handlers.UserRegister)
 		r.Get("/spotauth", a.Handlers.SpotifyAuthorization)
+		r.Get("/newspotaccesstoken", a.Handlers.NewAccessTokenRequest)
 		r.Get("/profile", a.Handlers.Profile)
 		r.Get("/profile/{profileID:[0-9]+}", a.Handlers.ProfileByID)
 		r.Get("/edit-profile/{profileID:[0-9]+}", a.Handlers.EditProfile)
@@ -37,6 +38,7 @@ func (a *application) routes() *chi.Mux {
 		r.Put("/update-profile/{profileID:[0-9]+}", a.Handlers.UpdateProfile)
 	})
 
+	a.App.Routes.Get("/spotauth/callback", a.Handlers.SpotifyAuthorizationCallback)
 	a.App.Routes.Get("/spotauth/callback", a.Handlers.SpotifyAuthorizationCallback)
 
 	a.App.Routes.Route("/messages", func(r chi.Router) {


### PR DESCRIPTION
New Spotify access token is now generated from user's Spotify refresh token, upon requesting the /matches page, if the access token expiry is 5 minutes or less from the current time.