### PR TITLE
Timestamps and sorting

### DIFF
--- a/myapp/data/message.go
+++ b/myapp/data/message.go
@@ -13,7 +13,7 @@ type Message struct {
 	UserID    int       `db:"user_id" json:"user_id"`
 	MatchID   int       `db:"match_id" json:"match_id"`
 	Content   string    `db:"content" json:"content"`
-	CreatedAt time.Time `db:"created_at"`
+	CreatedAt time.Time `db:"created_at" json:"created_at"`
 }
 
 // Table returns the table name associated with this model in the database

--- a/myapp/data/raw_query.go
+++ b/myapp/data/raw_query.go
@@ -61,7 +61,7 @@ func (r *RawQuery) MatchQuery(user User, settings Settings) ([]int, error) {
 	return userIDs, nil
 }
 
-func (r *RawQuery) ThreadPreviewQuery(userID int, otherUserID int) (string, string, string, error) {
+func (r *RawQuery) ThreadPreviewQuery(userID int, otherUserID int) (string, string, string, time.Time, error) {
 
 	// query to find content of latest message, and the time for that message
 	q1 := `select m.content, m.created_at
@@ -73,7 +73,7 @@ func (r *RawQuery) ThreadPreviewQuery(userID int, otherUserID int) (string, stri
 	q1rows, err := upper.SQL().Query(q1)
 	if err != nil {
 		fmt.Println("problem with query within func ThreadPreviewQuery", q1rows, err)
-		return "", "", "", err
+		return "", "", "", time.Time{}, err
 	}
 
 	// query to get other-user's profile image url
@@ -84,7 +84,7 @@ func (r *RawQuery) ThreadPreviewQuery(userID int, otherUserID int) (string, stri
 	q2rows, err := upper.SQL().Query(q2)
 	if err != nil {
 		fmt.Println("problem with query within func ThreadPreviewQuery", q2rows, err)
-		return "", "", "", err
+		return "", "", "", time.Time{}, err
 	}
 
 	// create containers to return
@@ -100,7 +100,7 @@ func (r *RawQuery) ThreadPreviewQuery(userID int, otherUserID int) (string, stri
 	if len(LatestMessagePreview) > 35 {
 		LatestMessagePreview = LatestMessagePreview[:35] + " . . ."
 	}
-	strLatestMessageTimeSent := LatestMessageTimeSent.Format(time.Kitchen)
+	strLatestMessageTimeSent := LatestMessageTimeSent.Format("Jan 2 3:04PM")
 	if LatestMessagePreview == "" {
 		strLatestMessageTimeSent = "No messages sent yet"
 	}
@@ -108,7 +108,7 @@ func (r *RawQuery) ThreadPreviewQuery(userID int, otherUserID int) (string, stri
 	q2rows.Next()
 	q2rows.Scan(&OtherUsersImage)
 
-	return LatestMessagePreview, strLatestMessageTimeSent, OtherUsersImage, nil
+	return LatestMessagePreview, strLatestMessageTimeSent, OtherUsersImage, LatestMessageTimeSent, nil
 }
 
 func (r *RawQuery) MatchesDisplayQuery(userID int) ([]MatchForDisplay, error) {

--- a/myapp/data/thread.go
+++ b/myapp/data/thread.go
@@ -1,5 +1,7 @@
 package data
 
+import "time"
+
 type Thread struct {
 	UserID                int
 	MatchID               int
@@ -7,4 +9,5 @@ type Thread struct {
 	LatestMessagePreview  string
 	LatestMessageTimeSent string
 	OtherUsersImage       string
+	TimeSentISO           time.Time
 }

--- a/myapp/views/matches.jet
+++ b/myapp/views/matches.jet
@@ -28,7 +28,7 @@
             text-align: center;
             font-family: 'Fredoka One', cursive;
             position: relative;
-            padding-top: 50%;
+            padding-top: 20%;
         }
         .wheel-frame {
             position: fixed;

--- a/myapp/views/message_thread.jet
+++ b/myapp/views/message_thread.jet
@@ -3,6 +3,7 @@
 {{block browserTitle()}}Welcome{{end}}
 
 {{block css()}}
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.15.1/moment.min.js"></script>
     <style>
         .message-input {
             width: 80%;
@@ -81,6 +82,7 @@
 <script>
     const userID = {{ userID }};
     const messageContainer = document.getElementById('message_container');
+    document.getElementById("message-input").focus();
 
     document.onkeydown = function(e){
         if(e.keyCode == 13){
@@ -122,10 +124,26 @@
 
                 for (let i = 0; i < data.length; i++) {
                     let message = data[i];
+
+                    var iso8601format = message.created_at;
+                    var currentTime = moment().toISOString();
+                    var fromNow_OneDay = moment().add(1, 'd');
+
+                    var momentTime = moment(iso8601format);
+                    var date = momentTime.utc().format('MMM D, YYYY');
+                    var time = momentTime.utc().format('h:mm A');
+                    var dateAndTime = time + "&nbsp;&nbsp;&nbsp;" + date;
+
                     if (message.user_id == userID) {
-                        messageContainer.innerHTML += `<div class="message sent float-left ms-auto mt-2">${message.content}</div>`;
+                        messageContainer.innerHTML +=
+                            `<div class="message sent float-left ms-auto mt-2">
+                                ${message.content}<br><span style="font-size:.8em">${dateAndTime}</span>
+                            </div>`;
                     } else {
-                        messageContainer.innerHTML += `<div class="message float-right me-auto mt-2">${message.content}</div>`;
+                        messageContainer.innerHTML +=
+                            `<div class="message float-right me-auto mt-2">
+                                ${message.content}<br><span style="font-size:.8em">${dateAndTime}</span>
+                            </div>`;
                     }
                 }
             });

--- a/myapp/views/messages.jet
+++ b/myapp/views/messages.jet
@@ -19,11 +19,11 @@
         }
         .noMessages {
             font-size: 1em;
-            color: white;
+            color: green;
             text-align: center;
             font-family: 'Fredoka One', cursive;
             position: relative;
-            padding-top: 50%;
+            padding-top: 5%;
         }
         body {
             padding-bottom: 50px;
@@ -222,7 +222,7 @@
 
     const noMessages = () => {
         const noMessageTemplate = `
-            <div class="container">
+            <div class="container-fluid">
                 <div class="noMessages">
                     <h1>Your message box is empty :(<br><br>Tap "link" on matches to see them here!</h1>
                 </div>


### PR DESCRIPTION
- Timestamps on thread previews updated
- Timestamps added to message bubbles 
- Thread previews now sort correctly--newest, down to oldest. Threads with no messages are included in this sort by using the link creation date.
- focus on text entry upon message_thread.jet page load
- message.go no-message notification now shows again