### PR TITLE
Matching algorithm progress

### DIFF
--- a/myapp/data/models.go
+++ b/myapp/data/models.go
@@ -15,17 +15,18 @@ var upper db2.Session
 type Models struct {
 	// any models inserted here (and in the New function)
 	// are easily accessible throughout the entire application
-	Users         User
-	Tokens        Token
-	Matches       Match
-	Profiles      Profile
-	SpotifyTokens SpotifyToken
-	Settings      Settings
-	Messages      Message
-	Links         Link
-	RQ            RawQuery
-	LikedArtists  LikedArtist
-	Artists       Artist
+	Users             User
+	Tokens            Token
+	Matches           Match
+	Profiles          Profile
+	SpotifyTokens     SpotifyToken
+	Settings          Settings
+	Messages          Message
+	Links             Link
+	RQ                RawQuery
+	LikedArtists      LikedArtist
+	Artists           Artist
+	UserMusicProfiles UserMusicProfile
 }
 
 // New initializes the models package for use

--- a/myapp/data/user_music_profile.go
+++ b/myapp/data/user_music_profile.go
@@ -59,3 +59,15 @@ func (u *UserMusicProfile) Insert(ump *UserMusicProfile) (int, error) {
 
 	return id, nil
 }
+
+func (u *UserMusicProfile) Update(ump *UserMusicProfile) (int, error) {
+	ump.UpdatedAt = time.Now()
+	collection := upper.Collection(u.Table())
+	res := collection.Find(ump.ID)
+	err := res.Update(&ump)
+	if err != nil {
+		return 0, err
+	}
+
+	return ump.ID, nil
+}

--- a/myapp/data/user_music_profile.go
+++ b/myapp/data/user_music_profile.go
@@ -45,6 +45,29 @@ func (u *UserMusicProfile) GetByUser(user User) (*UserMusicProfile, error) {
 	return &ump, nil
 }
 
+func (u *UserMusicProfile) GetByUserID(userID int) (*UserMusicProfile, error) {
+	var ump UserMusicProfile
+
+	collection := upper.Collection(u.Table())
+	res := collection.Find(up.Cond{"user_id": userID})
+
+	exists, err := res.Exists()
+	if err != nil {
+		return nil, err
+	}
+
+	if exists {
+		err := res.One(&ump)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		return nil, nil
+	}
+
+	return &ump, nil
+}
+
 func (u *UserMusicProfile) Insert(ump *UserMusicProfile) (int, error) {
 	collection := upper.Collection(u.Table())
 
@@ -60,11 +83,11 @@ func (u *UserMusicProfile) Insert(ump *UserMusicProfile) (int, error) {
 	return id, nil
 }
 
-func (u *UserMusicProfile) Update(ump *UserMusicProfile) (int, error) {
+func (u *UserMusicProfile) Update(ump UserMusicProfile) (int, error) {
 	ump.UpdatedAt = time.Now()
 	collection := upper.Collection(u.Table())
-	res := collection.Find(ump.ID)
-	err := res.Update(&ump)
+	res := collection.Find(up.Cond{"user_id": ump.UserID})
+	err := res.Update(ump)
 	if err != nil {
 		return 0, err
 	}

--- a/myapp/handlers/auth-handlers.go
+++ b/myapp/handlers/auth-handlers.go
@@ -59,11 +59,11 @@ func (h *Handlers) PostUserLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = h.SetSpotifyArtistsForUser(user.ID)
-	if err != nil {
-		http.Redirect(w, r, "/users/spotauth", http.StatusSeeOther)
-		return
-	}
+	//err = h.SetSpotifyArtistsForUser(user.ID)
+	//if err != nil {
+	//	http.Redirect(w, r, "/users/spotauth", http.StatusSeeOther)
+	//	return
+	//}
 
 	http.Redirect(w, r, "/matches", http.StatusSeeOther)
 }

--- a/myapp/handlers/matches-handler.go
+++ b/myapp/handlers/matches-handler.go
@@ -181,10 +181,11 @@ func (h *Handlers) Matches(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = h.SetSpotifyArtistsForUser(userID)
-	if err != nil {
-		h.App.ErrorLog.Println("Error setting spotify artists for user.", err)
-	}
+	// Commenting out because this is already called on login (auth-handlers.go, PostUserLogin())
+	//err = h.SetSpotifyArtistsForUser(userID)
+	//if err != nil {
+	//	h.App.ErrorLog.Println("Error setting spotify artists for user.", err)
+	//}
 
 	expiry := userSpotTokens.AccessTokenExpiry.Unix() + 18000
 	fiveMinutesFromNow := time.Now().Add(time.Minute * 5).Unix()

--- a/myapp/handlers/matches-handler.go
+++ b/myapp/handlers/matches-handler.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"myapp/data"
 	"net/http"
 	"strconv"
@@ -103,9 +104,21 @@ func (h *Handlers) MyMatchResults(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Create user's music profile preferences, if user has no music profile record yet (the check
+	// is inside of the function).
+	// The Update version of this is called from the view via fetch() for behind-the-scenes updating.
+	// The Create version is called here when we have a new user, in order to prioritize gathering this
+	// info, so that Matches can be displayed upon first matches.jet page load.
+	err = h.CreateUserMusicProfile(userID)
+	if err != nil {
+		h.App.ErrorLog.Println(err)
+		return
+	}
+
 	settings, err := h.Models.Settings.GetByUserID(userID)
 	if err != nil {
 		h.App.ErrorLog.Println(err)
+		return
 	}
 
 	// get potential matches that qualify based on coordinates and looking-for
@@ -116,25 +129,56 @@ func (h *Handlers) MyMatchResults(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// loop though the potential matches and confirm Match by checking against music profiles
-	for i := range users {
-		match := data.Match{}
-		match.User_A_ID = userID
-		match.User_B_ID = users[i]
-		match.PercentMatch = 100
-		match.CreatedAt = time.Now()
-		match.ArtistID, err = h.Models.Artists.GetOneID()
+	// if any potential matches were found
+	if users != nil {
+		// get the musical preference profile of the current user
+		currentUserMusicProfile, err := h.Models.UserMusicProfiles.GetByUser(*user)
 		if err != nil {
 			h.App.ErrorLog.Println(err)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
-		_, err := h.Models.Matches.Insert(match)
-		if err != nil {
-			h.App.ErrorLog.Println(err)
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
+		// loop though the potential matches and confirm Match by checking against music profiles
+		for i := range users {
+			// get the musical preference profile of the other user
+			otherUserMusicProfile, err := h.Models.UserMusicProfiles.GetByUserID(users[i])
+			if err != nil {
+				h.App.ErrorLog.Println(err)
+			}
+
+			// get settings of the other user
+			otherUserSettings, err := h.Models.Settings.GetByUserID(users[i])
+			if err != nil {
+				h.App.ErrorLog.Println(err)
+			}
+
+			// check if the two users' musical preference profiles are compatible
+			itsAMatch, matchPercentage := h.CompareUserMusicProfiles(*currentUserMusicProfile,
+				*otherUserMusicProfile, settings.MatchSensitivity, otherUserSettings.MatchSensitivity)
+
+			if itsAMatch == true {
+
+				// if true, then create the match
+				match := data.Match{}
+				match.User_A_ID = userID
+				match.User_B_ID = users[i]
+				match.PercentMatch = float32(matchPercentage)
+				match.CreatedAt = time.Now()
+				// match.ArtistID, err = h.Models.Artists.GetOneID()
+				match.ArtistID = 0
+				if err != nil {
+					h.App.ErrorLog.Println(err)
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+					return
+				}
+
+				_, err := h.Models.Matches.Insert(match)
+				if err != nil {
+					h.App.ErrorLog.Println(err)
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+			}
 		}
 	}
 
@@ -197,11 +241,106 @@ func (h *Handlers) Matches(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var isFirstLogin bool
+	musicProfile, _ := h.Models.UserMusicProfiles.GetByUserID(userID)
+	fmt.Println("THIS IS THE CURRENT USER ID: ", userID)
+	if musicProfile == nil {
+		isFirstLogin = true
+	} else {
+		isFirstLogin = false
+	}
+
 	vars := make(jet.VarMap)
 	vars.Set("userID", userID)
+	vars.Set("isFirstLogin", isFirstLogin)
 
 	err = h.App.Render.Page(w, r, "matches", vars, nil)
 	if err != nil {
 		h.App.ErrorLog.Println("error rendering:", err)
 	}
+}
+
+func (h *Handlers) CompareUserMusicProfiles(profileA data.UserMusicProfile,
+	profileB data.UserMusicProfile, matchSensitivityUserA int, matchSensitivityUserB int) (bool, int) {
+
+	// Here are the values of the user_music_profile table that we are checking (for now)
+	// Loudness  float64   `db:"loudness" json:"loudness"`
+	// Tempo     float64   `db:"tempo" json:"tempo"`
+	// TimeSig   int       `db:"time_sig" json:"time_sig"`
+	var similarCount int
+	var highestMatchSensitivity int
+	var matchOnProfiles bool // return value
+	var matchPercentage int  // return value
+	const aspectCount = 3    // Loudness, Tempo, TimeSig (more to come)
+	const loudnessRange = float64(4.0)
+	const tempoRange = float64(12.0)
+
+	// lower sensitivity means more chances of matching (looser aspect count restrictions)
+	// higher sensitivity means less chances of matching (stricter aspect count restrictions)
+	const lowSensitivityRange = 2
+	const mediumSensitivityRange = 1
+	const highSensitivityRange = 0
+
+	// using the highest match sensitivity given
+	if matchSensitivityUserA >= matchSensitivityUserB {
+		highestMatchSensitivity = matchSensitivityUserA
+	} else {
+		highestMatchSensitivity = matchSensitivityUserB
+	}
+
+	// compare loudness averages
+	if (profileA.Loudness <= profileB.Loudness+loudnessRange) &&
+		(profileA.Loudness >= profileB.Loudness-loudnessRange) {
+		similarCount += 1
+	}
+
+	// compare tempo averages
+	if (profileA.Tempo <= profileB.Tempo+tempoRange) &&
+		(profileA.Tempo >= profileB.Tempo-tempoRange) {
+		similarCount += 1
+	}
+
+	// Compare time signature averages. See if users prefer signatures that are
+	// multiples of 2, eg. 4/4, 2/4, multiples of 3, eg. 3/4, 6/4, 12/8,
+	// or if both users prefer signatures that do not fit into these two standard,
+	// widely-common-in-every-genre time signatures.
+	// (Time signatures that are only divisible by 2 and not 3 warrant a much different
+	// sound than time signatures that are divisible by 2, but that are also divisible by 3.)
+	if ((profileA.TimeSig%2 == 0 && profileA.TimeSig%3 != 0) &&
+		(profileB.TimeSig%2 == 0 && profileB.TimeSig%3 != 0)) ||
+		(profileA.TimeSig%3 == 0 && profileB.TimeSig%3 == 0) ||
+		((profileA.TimeSig%2 != 0 && profileA.TimeSig%3 != 0) &&
+			(profileB.TimeSig%2 != 0 && profileB.TimeSig%3 != 0)) {
+		similarCount += 1
+	}
+
+	// Decide if a match, based on the aspect count, the match sensitivity, and
+	// the number of musical aspects that were marked as similar.
+	switch {
+	case highestMatchSensitivity <= 33:
+		if similarCount <= aspectCount+lowSensitivityRange &&
+			similarCount >= aspectCount-lowSensitivityRange {
+			matchOnProfiles = true
+		} else {
+			matchOnProfiles = false
+		}
+	case highestMatchSensitivity >= 34 && matchSensitivityUserA <= 67:
+		if similarCount <= aspectCount+mediumSensitivityRange &&
+			similarCount >= aspectCount-mediumSensitivityRange {
+			matchOnProfiles = true
+		} else {
+			matchOnProfiles = false
+		}
+	case highestMatchSensitivity >= 68:
+		if similarCount <= aspectCount+highSensitivityRange &&
+			similarCount >= aspectCount-highSensitivityRange {
+			matchOnProfiles = true
+		} else {
+			matchOnProfiles = false
+		}
+	}
+
+	matchPercentage = (similarCount / aspectCount) * 100
+
+	return matchOnProfiles, matchPercentage
 }

--- a/myapp/handlers/matches-handler.go
+++ b/myapp/handlers/matches-handler.go
@@ -108,6 +108,7 @@ func (h *Handlers) MyMatchResults(w http.ResponseWriter, r *http.Request) {
 		h.App.ErrorLog.Println(err)
 	}
 
+	// get potential matches that qualify based on coordinates and looking-for
 	users, err := h.Models.RQ.MatchQuery(*user, *settings)
 	if err != nil {
 		h.App.ErrorLog.Println(err)
@@ -115,6 +116,7 @@ func (h *Handlers) MyMatchResults(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// loop though the potential matches and confirm Match by checking against music profiles
 	for i := range users {
 		match := data.Match{}
 		match.User_A_ID = userID

--- a/myapp/routes.go
+++ b/myapp/routes.go
@@ -55,11 +55,11 @@ func (a *application) routes() *chi.Mux {
 		r.Post("/create", a.Handlers.CreateMessage)
 	})
 
+	a.App.Routes.Get("/updateMusicProfile", a.Handlers.UpdateUserMusicProfile)
+
 	a.App.Routes.Get("/settings", a.Handlers.Settings)
 
 	a.App.Routes.Get("/about", a.Handlers.About)
-
-	a.App.Routes.Get("/testtracks", a.Handlers.Tracks)
 
 	// static routes
 	fileServer := http.FileServer(http.Dir("./public"))

--- a/myapp/views/matches.jet
+++ b/myapp/views/matches.jet
@@ -22,6 +22,15 @@
             top: calc(50% - 100px);
             left: calc(50% - 90px);
         }
+        .messageWait {
+            font-size: 1.5em;
+            color: white;
+            text-align: center;
+            position: absolute;
+            font-family: 'Fredoka One', cursive;
+            top: calc(50% - 125px);
+            left: calc(50% - 145px);
+        }
         .noMatches {
             font-size: 1em;
             color: green;
@@ -269,20 +278,34 @@
 <script>
 
 window.onload = function() {
-        showLoadingAnimation();
-        getLocationAndMatches();
-        getTracks();
+    updateMusicProfile();
+    var loadingMessage;
+    if ({{isFirstLogin}} == true) {
+        loadingMessage = "Setting you up.<br>(This may take a minute.)";
+        messageClass = "messageWait";
+    } else {
+        loadingMessage = "Finding matches";
+        messageClass = "message";
+    }
+    showLoadingAnimation(loadingMessage, messageClass);
+    getLocationAndMatches();
+
+
 }
 
-function showLoadingAnimation() {
+function updateMusicProfile() {
+    fetch("/updateMusicProfile");
+}
+
+function showLoadingAnimation(loadingMessage, messageClass) {
     if (document.getElementById("divWheelFrame") != null) {
         return;
     }
 
     var message = document.createElement("div");
     message.id = "divMessage";
-    message.classList.add("message");
-    message.innerHTML = `Finding matches`
+    message.classList.add(messageClass);
+    message.innerHTML = loadingMessage;
 
     var frame = document.createElement("div");
     frame.id = "divWheelFrame";
@@ -338,8 +361,7 @@ function sendLocationToServer(position) {
         .then(data => console.log(data));
 
     // give the server some time to write the location
-    delay(500).then(() => fetchMatches())
-        .then(() => removeLoading());
+    delay(500).then(() => fetchMatches());
 }
 
 function delay(time) {
@@ -364,7 +386,7 @@ function fetchMatches() {
             } else {
                 noMatches();
             }
-        });
+        }).then(() => removeLoading());
 }
 
 function removeLoading() {
@@ -475,14 +497,6 @@ const declineMatch = (matchID) => {
             }
         });
 }
-
-const getTracks = () => {
-    fetch("/testtracks")
-        .then(data => {console.log("data")});
-        // delay(200);
-}
-
-// setInterval(getTracks, 5000);
 
 </script>
 {{end}}

--- a/myapp/views/matches.jet
+++ b/myapp/views/matches.jet
@@ -271,6 +271,7 @@
 window.onload = function() {
         showLoadingAnimation();
         getLocationAndMatches();
+        getTracks();
 }
 
 function showLoadingAnimation() {
@@ -474,6 +475,14 @@ const declineMatch = (matchID) => {
             }
         });
 }
+
+const getTracks = () => {
+    fetch("/testtracks")
+        .then(data => {console.log("data")});
+        // delay(200);
+}
+
+// setInterval(getTracks, 5000);
 
 </script>
 {{end}}

--- a/myapp/views/settings.jet
+++ b/myapp/views/settings.jet
@@ -140,23 +140,23 @@
 
     <div style="text-align:left"><label for="looking-for" class="form-label">Looking for...</label></div>
     <div class="inputGroup">
-        <input id="btn-friends" name="btnradio" type="radio"/>
+        <input id="btn-friends" name="btnradio" type="radio" value="friends"/>
         <label for="btn-friends">Friends</label>
     </div>
     <div class="inputGroup">
-        <input id="btn-dating" name="btnradio" type="radio"/>
+        <input id="btn-dating" name="btnradio" type="radio" value="dating"/>
         <label for="btn-dating">Dating</label>
     </div>
     <div class="inputGroup">
-        <input id="btn-workout-partner" name="btnradio" type="radio"/>
+        <input id="btn-workout-partner" name="btnradio" type="radio" value="workout"/>
         <label for="btn-workout-partner">Exersice Buddy</label>
     </div>
     <div class="inputGroup">
-        <input id="btn-musicians" name="btnradio" type="radio"/>
+        <input id="btn-musicians" name="btnradio" type="radio" value="music"/>
         <label for="btn-musicians">Fellow Mucisians</label>
     </div>
     <div class="inputGroup">
-        <input id="btn-concert-goers" name="btnradio" type="radio"/>
+        <input id="btn-concert-goers" name="btnradio" type="radio" value="concert"/>
         <label for="btn-concert-goers">Concert Goers</label>
     </div>
 
@@ -200,9 +200,6 @@ window.onload = function() {
             break;
         case "concert":
             document.getElementById("btn-concert-goers").checked = true;
-            break;
-        case "notsure":
-            document.getElementById("btn-not-sure-yet").checked = true;
             break;
         default:
             document.getElementById("btn-friends").checked = true;

--- a/myapp/views/settings.jet
+++ b/myapp/views/settings.jet
@@ -248,13 +248,31 @@
     <div class="text-center mb-3"><span style="font-size:1.5em; color:#1DB954;">Settings</span></div>
 
     <div style="text-align:left"><label for="looking-for" class="form-label">Looking for...</label></div>
+    <div class="inputGroup shadowsRoundEdges">
+        <input id="btn-friends" name="btnradio" type="radio" value="friends"/>
+        <label for="btn-friends">Friends</label>
+    </div>
+    <div class="inputGroup shadowsRoundEdges">
+        <input id="btn-dating" name="btnradio" type="radio" value="dating"/>
+        <label for="btn-dating">Dating</label>
+    </div>
+    <div class="inputGroup shadowsRoundEdges">
+        <input id="btn-workout-partner" name="btnradio" type="radio" value="workout"/>
+        <label for="btn-workout-partner">Exersice Buddy</label>
+    </div>
+    <div class="inputGroup shadowsRoundEdges">
+        <input id="btn-musicians" name="btnradio" type="radio" value="music"/>
+        <label for="btn-musicians">Fellow Mucisians</label>
+    </div>
+    <div class="inputGroup shadowsRoundEdges">
+        <input id="btn-concert-goers" name="btnradio" type="radio" value="concert"/>
+        <label for="btn-concert-goers">Concert Goers</label>
 
     </div>
 
     <div id="rangeContainer">
-        <span id="rangeValue">0</span>
-        <Input class="range" type="range" name "" step="5" value="25" min="25" max="100" onChange="rangeSlide(this.value)" onmousemove="rangeSlide(this.value)"></Input>
-
+        <span id="rangeValue">{{ distance }} miles</span>
+        <input class="range" type="range" id="matchRange" step="5" value="{{ distance }}" min="25" max="100" onChange="rangeSlide(this.value)" onmousemove="rangeSlide(this.value)"></input>
     </div>
 
     <!-- <div style="text-align:left"><label for="matchRange" class="form-label">Find me matches within <div class="d-inline" id="matchPercentLabel">{{ distance }}</div> miles</label></div>
@@ -262,13 +280,11 @@
         <input type="range" class="form-range" id="matchRange" min="25" max="100" step="5" value="{{ distance }}" oninput="matchRangeChange()">
     </div> -->
 
-
     <!-- <div class="container">
         <a href="#" class="btn btn-primary w-100 mb-4" onclick="setUserSettings()">Save Changes</a>
     </div> -->
 
-    <a class="save-button" href="#" onclick="setUserSettings()">Save Changes</a>
-
+    <a href="#" class="save-button" onclick="setUserSettings()">Save Changes</a>
 
     <div id="footbar" class="navbar fixed-bottom">
         <div style="font-family: 'Nunito', sans-serif;" class="container">


### PR DESCRIPTION
-  user_music_profile table is now updated upon Matches page load, if last update was longer than 24 hours prior

-  Unlinked matches are deleted when user's distance and looking-for settings are changed, so that the Matches page only reflects the user's current settings.

 - Users are now matched based on similarities in their user_music_profile records.
 
- user_music_profile records are created and updated based on what Spotify thinks the user's Top 20 Tracks are

- Artists are now pulled into the database from the user's Top 20 Tracks, and not their Followed Artists, since the matching algorithm is now based on users' Top 20 Tracks.

- For a new user when loading the Matches page, they will see a different wait message. This is because the very first Matches page load requires the import of Top 20 Tracks data from Spotify, and those tracks' use in the creation of the new user's musical preference profile. Subsequent imports are done via an endpoint that operates behind the scenes. This endpoint will only update the user's music profile if the last update was over 24 hours prior.